### PR TITLE
implement auto-projectile group

### DIFF
--- a/README.org
+++ b/README.org
@@ -201,6 +201,9 @@ For convenience, the macro =bufler-defgroups= provides a sort of DSL, a concise 
      (group-not "*special*" (auto-file))
      (auto-mode))
     (group
+     ;; Subgroup collecting buffers in a projectile project.
+     (auto-projectile))
+    (group
      ;; Subgroup collecting buffers in a version-control project,
      ;; grouping them by directory.
      (auto-project))
@@ -225,6 +228,7 @@ The following group types are available in =bufler-defgroups=.  Note that each o
      -  ~auto-indirect~  Whether the buffer is indirect (e.g. a cloned indirect buffer).
      -  ~auto-mode~  Buffer's major mode.
      -  ~auto-project~  Buffer's version-control project directory according to ~project.el~.
+     -  ~auto-projectile~ Buffer's project as defined in the ~projectile~ package (if installed).
      -  ~auto-special~  Whether the buffer is special (i.e. whether its name starts with ~*~).
      -  ~auto-tramp~  Whether the buffer is opened via Tramp.
      -  ~auto-workspace~  The buffer's named workspace, if any.

--- a/bufler.el
+++ b/bufler.el
@@ -953,6 +953,16 @@ NAME, okay, `checkdoc'?"
               (project-root (car (project-roots project))))
     (concat "Project: " project-root)))
 
+(eval-and-compile
+  (declare-function projectile-project-name "ext:projectile" t t)
+  (if (require 'projectile nil 'noerror)
+      (bufler-defauto-group projectile
+        (if-let ((project (with-current-buffer buffer
+                            (projectile-project-name))))
+            (concat "Projectile: " project)))
+    (bufler-defauto-group projectile
+      (ignore buffer))))
+
 (bufler-defauto-group tramp
   (when-let* ((host (file-remote-p (buffer-local-value 'default-directory buffer)
                                    'host)))
@@ -993,6 +1003,7 @@ See documentation for details."
                  (auto-indirect () `(bufler-group 'auto-indirect))
                  (auto-mode () `(bufler-group 'auto-mode))
                  (auto-project () `(bufler-group 'auto-project))
+                 (auto-projectile () `(bufler-group 'auto-projectile))
                  (auto-tramp () `(bufler-group 'auto-tramp))
                  (auto-workspace () `(bufler-group 'auto-workspace)))
      (list ,@groups)))
@@ -1053,6 +1064,9 @@ See documentation for details."
      ;; Group remaining buffers by whether they're file backed, then by mode.
      (group-not "*special*" (auto-file))
      (auto-mode))
+    (group
+     ;; Subgroup collecting buffers in a projectile project.
+     (auto-projectile))
     (group
      ;; Subgroup collecting buffers in a version-control project,
      ;; grouping them by directory.


### PR DESCRIPTION
fix #10

When projectile is present, define an auto-projectile group using projectile-project-name as the group name.  When projectile is absent the auto-projectile group does nothing.