### PR TITLE
Fix: auto-projectile should ignore the default project named "-"

### DIFF
--- a/bufler.el
+++ b/bufler.el
@@ -957,9 +957,10 @@ NAME, okay, `checkdoc'?"
   (declare-function projectile-project-name "ext:projectile" t t)
   (if (require 'projectile nil 'noerror)
       (bufler-defauto-group projectile
-        (if-let ((project (with-current-buffer buffer
-                            (projectile-project-name))))
-            (concat "Projectile: " project)))
+        (let ((project (with-current-buffer buffer
+                         (projectile-project-name))))
+          (when (and project (not (equal project "-")))
+            (concat "Projectile: " project))))
     (bufler-defauto-group projectile
       (ignore buffer))))
 


### PR DESCRIPTION
This is a minor but important fix. It turns out `projectile-project-name` returns a default "-" when it can't determine a project name. As a result the `auto-projectile` predicate matches all buffers, which is a problem if you put `auto-projectile` early in your `bufler-groups` list. This patch suppresses this default "-" project and returns a nil instead.
