### PR TITLE
Use bufler-format-buffer to format Name column

### DIFF
--- a/bufler.el
+++ b/bufler.el
@@ -672,7 +672,10 @@ buffer's depth in the group tree."
                                        'face 'bufler-mode))))
     (concat (make-string (* 2 depth) ? )
             mode-annotation
-            (buffer-name buffer))))
+            (buffer-name buffer)
+            (propertize (if (buffer-modified-p buffer)
+                            "*" "")
+                        'face 'font-lock-warning-face))))
 
 (bufler-define-column "Size" 'bufler-size
   (ignore depth)


### PR DESCRIPTION
Pardon me as if I'm missing something obvious, but it seems that he Name column doesn't indicate modified state in any way. Is there a way to show this?

There seems to be a function for it, but I couldn't figure out whether it was used anywhere so I added a call to it in the Name column function.