### PR TITLE
Fix: Update comments referring to Mr. Buffer to Bufler

### DIFF
--- a/bufler-workspace.el
+++ b/bufler-workspace.el
@@ -37,7 +37,7 @@
 ;;;; Customization
 
 (defgroup bufler-workspace nil
-  "Options for Mr. Buffer's workspaces."
+  "Options for Bufler's workspaces."
   :group 'bufler)
 
 (defcustom bufler-workspace-ignore-case t
@@ -159,7 +159,7 @@ appear in a named workspace, the buffer must be matched by an
 
 ;;;###autoload
 (define-minor-mode bufler-workspace-mode
-  "When active, set the frame title according to current Mr. Buffer group."
+  "When active, set the frame title according to current Bufler group."
   :global t
   (let ((lighter '(bufler-workspace-mode (:eval (bufler-workspace-mode-lighter)))))
     (if bufler-workspace-mode


### PR DESCRIPTION
Hey @alphapapa!  Noticed a couple of old references to "Mr. Buffer" when looking at Bufler's documentation, here's a PR to fix them.

Side question: would you be willing to accept a PR to disable Bufler's mode line lighter via config variable?  I'm displaying the workspace path in my Polybar panel so I don't need to also show it in the mode line.