### PR TITLE
require dash when compiling workspace-tabs

### DIFF
--- a/bufler-workspace-tabs.el
+++ b/bufler-workspace-tabs.el
@@ -29,6 +29,7 @@
 ;;;; Requirements
 
 (require 'map)
+(eval-when-compile (require 'dash))
 
 (require 'bufler-workspace)
 


### PR DESCRIPTION
Without this, bytecompiling the autoloaded bufler-workspace-tabs function fails

In toplevel form:
autoloads.28.0.50.el:13096:27: Warning: Unused lexical argument ‘workspace’
autoloads.28.0.50.el:13096:27: Warning: Unused lexical variable
    ‘bufler-vc-refresh’
autoloads.28.0.50.el:13109:404: Warning: ‘((&plist :name :path) workspace)’ is
    a malformed function