### PR TITLE
[PATCH] Discussion around non-consuming groups in bufler-group-tree and using this for workspaces

### DIFF
--- a/bufler-workspace.el
+++ b/bufler-workspace.el
@@ -141,21 +141,26 @@ act as if SET-WORKSPACE-P is non-nil."
     (switch-to-buffer selected-buffer)))
 
 ;;;###autoload
+(defun bufler-workspace-list-named-workspaces ()
+  "Return the list of current named workspaces."
+  (seq-uniq
+   (cl-loop for buffer in (buffer-list)
+            when (buffer-local-value 'bufler-workspace-names buffer)
+            append it)))
+
+;;;###autoload
 (defun bufler-workspace-buffer-name-workspace (&optional name)
   "Set current buffer's workspace to NAME.
 If NAME is nil (interactively, with prefix), unset the buffer's
-workspace name.  This sets the buffer-local variable
-`bufler-workspace-name'.  Note that, in order for a buffer to
+workspace name.  This prepends to the buffer-local variable
+`bufler-workspace-names'.  Note that, in order for a buffer to
 appear in a named workspace, the buffer must be matched by an
 `auto-workspace' group before any other group."
   (interactive (list (unless current-prefix-arg
                        (completing-read "Named workspace: "
-                                        (seq-uniq
-                                         (cl-loop for buffer in (buffer-list)
-                                                  when (buffer-local-value 'bufler-workspace-name buffer)
-                                                  collect it))))))
+                                        (bufler-workspace-list-named-workspaces)))))
   (setf bufler-cache nil)
-  (setq-local bufler-workspace-name name))
+  (add-to-list (make-local-variable 'bufler-workspace-names) name))
 
 ;;;###autoload
 (define-minor-mode bufler-workspace-mode

--- a/bufler.el
+++ b/bufler.el
@@ -97,8 +97,8 @@ Usually this will be something like \"/usr/share/emacs/VERSION\".")
 (defvar bufler-cache nil
   "Cache of computed buffer groups.")
 
-(defvar bufler-workspace-name nil
-  "The buffer's named workspace, if any.")
+(defvar bufler-workspace-names nil
+  "A list of named workspaces owning the buffer, if any.")
 
 (defvar bufler-cache-related-dirs (make-hash-table :test #'equal)
   "Cache of relations between directories.
@@ -433,7 +433,7 @@ NAME, okay, `checkdoc'?"
 
 (declare-function bufler-workspace-buffer-name-workspace "bufler-workspace")
 (bufler-define-buffer-command name-workspace
-  "Set buffer's workspace name.
+  "Adds to buffer's workspace names.
 With prefix, unset it."
   (lambda (buffer)
     (with-current-buffer buffer
@@ -442,7 +442,7 @@ With prefix, unset it."
                  (completing-read "Named workspace: "
                                   (seq-uniq
                                    (cl-loop for buffer in (buffer-list)
-                                            when (buffer-local-value 'bufler-workspace-name buffer)
+                                            when (buffer-local-value 'bufler-workspace-names buffer)
                                             collect it)))))))
 
 ;;;;; Group commands
@@ -1029,8 +1029,9 @@ NAME, okay, `checkdoc'?"
     (concat "Tramp: " host)))
 
 (bufler-defauto-group workspace
-  (when-let* ((name (buffer-local-value 'bufler-workspace-name buffer)))
-    name))
+  (when-let* ((names (buffer-local-value 'bufler-workspace-names buffer)))
+    names))
+
 
 ;;;;;; Group-defining macro
 

--- a/bufler.el
+++ b/bufler.el
@@ -1030,7 +1030,7 @@ NAME, okay, `checkdoc'?"
 
 (bufler-defauto-group workspace
   (when-let* ((names (buffer-local-value 'bufler-workspace-names buffer)))
-    names))
+    (mapcar (lambda (name) (concat "Workspace: " name)) names)))
 
 
 ;;;;;; Group-defining macro


### PR DESCRIPTION
~~Based on the ideas in d623605~~ Not anymore, see the thread.

The main goals are to :
- [x] make `buffer-workspace` local varible a list instead of a string (would warrant a breaking rename change)
- [x] list all buffers maybe multiple times when they have multiple tags, within the `auto-workspace` group helper
- [ ] Do not kill a buffer from killing a whole workspace if the buffer lives in another workspace (i.e. `(delete (make-local-variable 'buffer-workspace) deleted-workspace)` and *then* check for the length of the list)
- [ ] ~~Fix the `group-tree` function which broke a few group labels when moved to a non-consuming implementation.~~

This below was true when I thought that non-consuming groups was what I wanted. "Allowing multiple workspaces per buffer" can be done without it.
> I actually do think that we could keep part of the old implementation, or even make the recursive helper function take an optional argument (`passthrough-p`) that would make the capture non consuming if set. This way, with new node types (or node metadata) in the `fns` tree we can build a tree with the consuming/non-consuming behaviour the user wants.

> I'll try to add documentation about the group-tree, took me a while to understand what I was trying