### PR TITLE
Change: Don't depend on deprecated dash-functional

### DIFF
--- a/bufler.el
+++ b/bufler.el
@@ -5,7 +5,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: https://github.com/alphapapa/bufler.el
 ;; Package-Version: 0.3-pre
-;; Package-Requires: ((emacs "26.3") (dash "2.17") (dash-functional "2.17") (f "0.17") (pretty-hydra "0.2.2") (magit-section "0.1"))
+;; Package-Requires: ((emacs "26.3") (dash "2.18") (f "0.17") (pretty-hydra "0.2.2") (magit-section "0.1"))
 ;; Keywords: convenience
 
 ;;; License:
@@ -52,7 +52,6 @@
 (require 'outline)
 
 (require 'dash)
-(require 'dash-functional)
 (require 'f)
 (require 'magit-section)
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218