### PR TITLE
Change required emacs version to 27

### DIFF
--- a/bufler.el
+++ b/bufler.el
@@ -5,7 +5,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: https://github.com/alphapapa/bufler.el
 ;; Package-Version: 0.3-pre
-;; Package-Requires: ((emacs "26.3") (dash "2.17") (dash-functional "2.17") (f "0.17") (pretty-hydra "0.2.2") (magit-section "0.1"))
+;; Package-Requires: ((emacs "27.1") (dash "2.17") (dash-functional "2.17") (f "0.17") (pretty-hydra "0.2.2") (magit-section "0.1"))
 ;; Keywords: convenience
 
 ;;; License:


### PR DESCRIPTION
Because of the use of [group-name](https://github.com/alphapapa/bufler.el/blob/097f4349920215bdd829fceabc1afdbba172c32a/bufler.el#L928), which got added in 27.1 ( https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-27#n3078 )