### PR TITLE
Silence "Function provided is already compiled"

### DIFF
--- a/bufler-group-tree.el
+++ b/bufler-group-tree.el
@@ -150,29 +150,38 @@
   "Return a grouping function that groups items matching all of PREDS.
 The resulting group is named NAME.  This can also be used with a
 single predicate to apply a name to a group."
-  (byte-compile (lambda (item)
+  (let ((and-fn (lambda (item)
                   (when (cl-every (lambda (fn)
                                     (funcall fn item))
                                   preds)
                     name))))
+    (if (byte-code-function-p and-fn)
+        and-fn
+      (byte-compile and-fn))))
 
 (defun bufler-group-tree-or (name &rest preds)
   ;; Copied from dash-functional.el.
   "Return a grouping function that groups items matching any of PREDS.
 The resulting group is named NAME."
-  (byte-compile (lambda (item)
+  (let ((or-fn (lambda (item)
                   (when (cl-some (lambda (fn)
                                    (funcall fn item))
                                  preds)
                     name))))
+    (if (byte-code-function-p or-fn)
+        or-fn
+      (byte-compile or-fn))))
 
 (defun bufler-group-tree-not (name pred)
   ;; Copied from dash-functional.el.
   "Return a grouping function that groups items which do not match PRED.
 The resulting group is named NAME."
-  (byte-compile (lambda (item)
+  (let ((not-fn (lambda (item)
                   (unless (funcall pred item)
                     name))))
+    (if (byte-code-function-p not-fn)
+        not-fn
+      (byte-compile not-fn))))
 
 ;;;;; Group-defining macro
 

--- a/bufler.el
+++ b/bufler.el
@@ -950,25 +950,34 @@ TYPE, okay, `checkdoc'?"
   "Return a grouping function that groups buffers matching all of PREDS.
 The resulting group is named NAME.  This can also be used with a
 single predicate to apply a name to a group."
-  (byte-compile (lambda (x)
+  (let ((and-fn (lambda (x)
                   (when (-all? (-cut funcall <> x) preds)
                     name))))
+    (if (byte-code-function-p and-fn)
+        and-fn
+      (byte-compile and-fn))))
 
 (defun bufler-or (name &rest preds)
   ;; Copied from dash-functional.el.
   "Return a grouping function that groups buffers matching any of PREDS.
 The resulting group is named NAME."
-  (byte-compile (lambda (x)
-                  (when (-any? (-cut funcall <> x) preds)
-                    name))))
+  (let ((or-fn (lambda (x)
+                 (when (-any? (-cut funcall <> x) preds)
+                   name))))
+    (if (byte-code-function-p or-fn)
+        or-fn
+      (byte-compile or-fn))))
 
 (defun bufler-not (name pred)
   ;; Copied from dash-functional.el.
   "Return a grouping function that groups buffers which do not match PRED.
 The resulting group is named NAME."
-  (byte-compile (lambda (x)
+  (let ((not-fn (lambda (x)
                   (unless (funcall pred x)
                     name))))
+    (if (byte-code-function-p not-fn)
+        not-fn
+      (byte-compile not-fn))))
 
 ;;;;;; Grouping predicates
 


### PR DESCRIPTION
It looks like some native-comp Emacs 28 configurations pre-compile the anonymous byte-compiled functions in [`bufler.el`](https://github.com/alphapapa/bufler.el/blob/bf5fdccbae6bb6dc51e31dc282805e32bb41e412/bufler.el#L948) and [`bufler-group-tree.el`](https://github.com/alphapapa/bufler.el/blob/bf5fdccbae6bb6dc51e31dc282805e32bb41e412/bufler-group-tree.el#L148), causing the editor to fuss in the echo area when invoking certain bufler commands.

I see a similar issue (#28) was reported before, but that it was closed pending some fundamental changes in v0.4. While those changes are being worked on, this patch should presently remediate the issue.